### PR TITLE
Support for newer versions using img.transparent vs. img.decoded.

### DIFF
--- a/Blank PNG Background.css
+++ b/Blank PNG Background.css
@@ -1,8 +1,8 @@
 @namespace url(http://www.w3.org/1999/xhtml);
-body > img.decoded {
+body > img.decoded, body > img.transparent {
   background: none !important;
 }
 
-body > img.decoded:hover {
+body > img.decoded:hover, body > img.transparent:hover {
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAAABlBMVEV7e3sAAAD2vrKOAAAAAnRSTlM7O/sqyyQAAAAfSURBVHja1c6hAQAAAAFB9l9aYwGBj5ceie4bZ0ZaKKW0AMmwXSJmAAAAAElFTkSuQmCC) !important;
 }


### PR DESCRIPTION
Hi,

I've been a big fan of your Stilig userstyle for some time now and recently came across this neat userstyle aswell. 

However it didn't work in Firefox 36, seems that `img.decoded` has been changed in favor of `img.transparent`, so here's a small patch that adds support for newer versions of Firefox. 

Thanks,
Tim
